### PR TITLE
chore: improve GitHub Actions workflow

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -6,7 +6,8 @@ name: Android Build
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - 'common/config/**'
       - 'common/**/*.gradle.kts'
@@ -20,7 +21,8 @@ jobs:
 
     steps:
       # ── Checkout ────────────────────────────────────────────────────────────
-      - uses: actions/checkout@v6
+      - name: Checkout 
+        uses: actions/checkout@v6
 
       # ── Node ────────────────────────────────────────────────────────────────
       - name: Install Node

--- a/.github/workflows/android-style.yml
+++ b/.github/workflows/android-style.yml
@@ -6,7 +6,8 @@ name: Android Code Style
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - 'android/src/**/*.java'
       - 'android/src/**/*.kt'
@@ -17,7 +18,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout
+        uses: actions/checkout@v6
 
       - name: Set up Java
         uses: actions/setup-java@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,13 +28,13 @@ jobs:
 
     steps:
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 
@@ -47,10 +47,10 @@ jobs:
         run: zensical build --clean --config-file docs/zensical.toml
 
       - name: Upload Pages
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ${{ github.workspace }}/docs/site
 
       - name: Deploy Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/gdscript-style.yml
+++ b/.github/workflows/gdscript-style.yml
@@ -6,7 +6,8 @@ name: GDScript Code Style
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - 'addon/src/**/*.gd'
       - 'demo/**/*.gd'
@@ -16,7 +17,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout
+        uses: actions/checkout@v6
 
       - name: Install gdtoolkit
         run: |

--- a/.github/workflows/gradle-kts-style.yml
+++ b/.github/workflows/gradle-kts-style.yml
@@ -6,7 +6,8 @@ name: Gradle Kotlin DSL Style
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - '**/*.gradle.kts'
 
@@ -15,7 +16,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout 
+        uses: actions/checkout@v6
 
       - name: Install Node
         uses: ./.github/actions/install-node

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -6,7 +6,8 @@ name: iOS Build
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - 'common/config/**'
       - 'common/**/*.gradle.kts'
@@ -21,7 +22,8 @@ jobs:
 
     steps:
       # ── Checkout ────────────────────────────────────────────────────────────
-      - uses: actions/checkout@v6
+      - name: Checkout 
+        uses: actions/checkout@v6
 
       # ── Node ────────────────────────────────────────────────────────────────
       - name: Install Node

--- a/.github/workflows/ios-style.yml
+++ b/.github/workflows/ios-style.yml
@@ -6,7 +6,8 @@ name: iOS Code Style
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - 'ios/src/**/*.m'
       - 'ios/src/**/*.mm'
@@ -18,7 +19,8 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout 
+        uses: actions/checkout@v6
 
       - name: Install SwiftLint
         run: brew install swiftlint

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -6,7 +6,8 @@ name: Sync Labels
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - '.github/config/labels.yml'
 
@@ -18,11 +19,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout
+        uses: actions/checkout@v6
         with:
           sparse-checkout: .github/config/labels.yml
 
-      - uses: EndBug/label-sync@v2
+      - name: Label Sync
+        uses: EndBug/label-sync@v2
         with:
           config-file: .github/config/labels.yml
           delete-other-labels: true

--- a/.github/workflows/properties-style.yml
+++ b/.github/workflows/properties-style.yml
@@ -6,7 +6,8 @@ name: Properties File Style
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - 'common/config/*.properties'
       - 'ios/config/*.properties'
@@ -16,7 +17,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout 
+        uses: actions/checkout@v6
 
       - name: Install editorconfig-checker
         uses: ./.github/actions/install-ec

--- a/.github/workflows/release-on-milestone.yml
+++ b/.github/workflows/release-on-milestone.yml
@@ -6,7 +6,8 @@ name: Draft Release on Milestone Close
 
 on:
   milestone:
-    types: [closed]
+    types:
+      - closed
 
 permissions:
   contents: write   # required to create releases and upload assets
@@ -21,7 +22,7 @@ jobs:
 
     steps:
       # ── Checkout ────────────────────────────────────────────────────────────
-      - name: Checkout repository
+      - name: Checkout 
         uses: actions/checkout@v6
         with:
           fetch-depth: 0

--- a/.github/workflows/script-style.yml
+++ b/.github/workflows/script-style.yml
@@ -6,7 +6,8 @@ name: Script Code Style
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - 'script/**/*.sh'
       - 'script/**/*.rb'
@@ -16,7 +17,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout
+        uses: actions/checkout@v6
 
       - name: Install Node
         uses: ./.github/actions/install-node


### PR DESCRIPTION
- upgrade actions
- name steps
- use yml list syntax

this fixes Node.js 20 actions are deprecation by moving all actions to Node.js 24 compatible version

## Linked issue
- Closes https://github.com/godot-mobile-plugins/godot-oauth2/issues/14 